### PR TITLE
bugfix/disable-logging

### DIFF
--- a/__tests__/perfume.spec.ts
+++ b/__tests__/perfume.spec.ts
@@ -101,21 +101,13 @@ describe('Perfume', () => {
       expect(spy).toHaveBeenCalledWith('⚡️ Perfume.js:', 'Recording already stopped.');
     });
 
-    it('should call log() when logging is true', () => {
+    it('should call log() with correct params', () => {
       spy = jest.spyOn(perfume, 'log');
       perfume.config.logging = true;
       perfume.start('metricName');
       perfume.end('metricName');
       expect(spy.mock.calls.length).toEqual(1);
       expect(spy).toHaveBeenCalledWith('metricName', 12346);
-    });
-
-    it('should not call log() when logging is false', () => {
-      spy = jest.spyOn(perfume, 'log');
-      perfume.config.logging = false;
-      perfume.start('metricName');
-      perfume.end('metricName');
-      expect(spy).not.toHaveBeenCalled();
     });
   });
 
@@ -157,6 +149,23 @@ describe('Perfume', () => {
   });
 
   describe('.log()', () => {
+    it('should not call window.console.log() if logging is disabled', () => {
+      perfume.config.logging = false;
+      spy = jest.spyOn(window.console, 'log');
+      perfume.log('', 0);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should call window.console.log() if logging is enabled', () => {
+      perfume.config.logging = true;
+      spy = jest.spyOn(window.console, 'log');
+      perfume.log('metricName', 12345);
+      const text = '%c ⚡️ Perfume.js: metricName 12345.00 ms';
+      const style = 'color: #ff6d00;font-size:12px;';
+      expect(spy.mock.calls.length).toEqual(1);
+      expect(spy).toHaveBeenCalledWith(text, style);
+    });
+
     it('should call logWarn if params are not correct', () => {
       spy = jest.spyOn(perfume, 'logWarn');
       perfume.log('', 0);
@@ -172,6 +181,7 @@ describe('Perfume', () => {
     });
 
     it('should call window.console.log() if params are correct', () => {
+      perfume.config.logging = true;
       spy = jest.spyOn(window.console, 'log');
       perfume.log('metricName', 12345);
       const text = '%c ⚡️ Perfume.js: metricName 12345.00 ms';

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -114,9 +114,7 @@ export default class Perfume {
     this.metrics[metricName].end = this.perf.now();
     this.perf.mark(metricName, 'end');
     const duration = this.perf.measure(metricName, this.metrics);
-    if (this.config.logging) {
-      this.log(metricName, duration);
-    }
+    this.log(metricName, duration);
     delete this.metrics[metricName];
     this.sendTiming(metricName, duration);
     return duration;
@@ -138,6 +136,9 @@ export default class Perfume {
    * Coloring Text in Browser Console
    */
   public log(metricName: string, duration: number): void {
+    if (!this.config.logging) {
+      return;
+    }
     if (!metricName) {
       this.logWarn(this.config.logPrefix, this.logMetric);
       return;
@@ -239,7 +240,7 @@ export default class Perfume {
   }
 
   private logWarn(prefix: string, message: string): void {
-    if (!this.config.warning) {
+    if (!this.config.warning || !this.config.logging) {
       return;
     }
     window.console.warn(prefix, message);


### PR DESCRIPTION
All console logging is now disabled when the `config.logging` flag is set to false.

- `log()` now checks for the current `config.logging` value.
- `logWarn()` also now checks for the current `config.logging` value.
- Removed check for `config.logging` value in `end()`. 
- Updated `log()` tests to match new behaviour + removed an existing (now defunct) test from `end()`.

Fixes issue #35 