### PR TITLE
fix: catch error on init-first-paint

### DIFF
--- a/__tests__/_mock.ts
+++ b/__tests__/_mock.ts
@@ -14,6 +14,22 @@ export const EventMock = {
   },
 } as Event;
 
+export class MockPerformanceObserver {
+  static simulateErrorOnObserve = false;
+
+  constructor(cb) {
+    (this as any).observe = () => {
+      if (MockPerformanceObserver.simulateErrorOnObserve) {
+        MockPerformanceObserver.simulateErrorOnObserve = false;
+        throw new Error('Simulated Error');
+      }
+      cb({ getEntries: () => entries });
+      return {};
+    };
+  }
+  disconnect() {}
+}
+
 export default {
   Date: {
     now: () => 1000,
@@ -50,15 +66,7 @@ export default {
       cb(3.2, EventMock);
     },
   },
-  PerformanceObserver: class {
-    constructor(cb) {
-      (this as any).observe = () => {
-        cb({ getEntries: () => entries });
-        return {};
-      };
-    }
-    disconnect() {}
-  },
+  PerformanceObserver: MockPerformanceObserver,
   defaultPerfumeConfig: {
     firstContentfulPaint: false,
     firstPaint: false,

--- a/__tests__/perfume.spec.ts
+++ b/__tests__/perfume.spec.ts
@@ -384,10 +384,7 @@ describe('Perfume', () => {
       (window as any).PerformanceObserver = mock.PerformanceObserver;
       perfume['initFirstPaint']();
       expect(spy.mock.calls.length).toEqual(1);
-      expect(spy).toHaveBeenCalledWith(
-        'Perfume.js:',
-        'initFirstPaint failed',
-      );
+      expect(spy).toHaveBeenCalledWith('Perfume.js:', 'initFirstPaint failed');
       expect(perfume['perfEmulated']).not.toBeDefined();
     });
 

--- a/__tests__/perfume.spec.ts
+++ b/__tests__/perfume.spec.ts
@@ -377,6 +377,20 @@ describe('Perfume', () => {
       expect(perfume['perfEmulated']).not.toBeDefined();
     });
 
+    it('should throw a logWarn if initFirstPaint fails', () => {
+      spy = jest.spyOn(perfume as any, 'logWarn');
+      (window as any).chrome = true;
+      mock.PerformanceObserver.simulateErrorOnObserve = true;
+      (window as any).PerformanceObserver = mock.PerformanceObserver;
+      perfume['initFirstPaint']();
+      expect(spy.mock.calls.length).toEqual(1);
+      expect(spy).toHaveBeenCalledWith(
+        'Perfume.js:',
+        'initFirstPaint failed',
+      );
+      expect(perfume['perfEmulated']).not.toBeDefined();
+    });
+
     it('should call firstContentfulPaint() with EmulatedPerformance', () => {
       delete (window as any).chrome;
       delete (window as any).PerformanceObserver;

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -354,7 +354,11 @@ export default class Perfume {
     // Checks if use Performance or the EmulatedPerformance instance
     if (Performance.supportedPerformanceObserver()) {
       this.logDebug('initFirstPaint.supportedPerformanceObserver');
-      this.perf.firstContentfulPaint(this.firstContentfulPaintCb.bind(this));
+      try {
+        this.perf.firstContentfulPaint(this.firstContentfulPaintCb.bind(this));        
+      } catch (e) {
+        this.logWarn(this.config.logPrefix, "initFirstPaint failed");
+      }
     } else if (this.perfEmulated) {
       this.logDebug('initFirstPaint.perfEmulated');
       this.perfEmulated.firstContentfulPaint(

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -355,9 +355,9 @@ export default class Perfume {
     if (Performance.supportedPerformanceObserver()) {
       this.logDebug('initFirstPaint.supportedPerformanceObserver');
       try {
-        this.perf.firstContentfulPaint(this.firstContentfulPaintCb.bind(this));        
+        this.perf.firstContentfulPaint(this.firstContentfulPaintCb.bind(this));
       } catch (e) {
-        this.logWarn(this.config.logPrefix, "initFirstPaint failed");
+        this.logWarn(this.config.logPrefix, 'initFirstPaint failed');
       }
     } else if (this.perfEmulated) {
       this.logDebug('initFirstPaint.perfEmulated');


### PR DESCRIPTION
We see errors indicating that the `paint` entry-type is not supported. In that case an exception is thrown by the browser:`Failed to execute 'observe' on 'PerformanceObserver': A Performance Observer MUST have a non-empty entryTypes attribute.` (see https://w3c.github.io/performance-timeline/#dom-performanceobserverinit-entrytypes for more information).

This happens for quite old versions of Chrome (eg 55, 56).

I think it's a good idea to let `Performance#firstContentfulPaint` fail in this case and handle the error in a try-catch block within `initFirstPaint`. However, I'm not sure what to do in this case. For now I'm more or less ignoring these errors and not logging any paint related things at all in this exceptional case. 