### PR TITLE
feat: add `customProperties` to `endPaint` to do custom reporting

### DIFF
--- a/__tests__/perfume.spec.ts
+++ b/__tests__/perfume.spec.ts
@@ -128,13 +128,22 @@ describe('Perfume', () => {
       );
     });
 
-    it('should call log() with correct params', () => {
+    it('should call log() with correct params (no optionals)', () => {
       spy = jest.spyOn(perfume, 'log');
       perfume.config.logging = true;
       perfume.start('metricName');
       perfume.end('metricName');
       expect(spy.mock.calls.length).toEqual(1);
-      expect(spy).toHaveBeenCalledWith('metricName', 12346);
+      expect(spy).toHaveBeenCalledWith('metricName', 12346, undefined);
+    });
+
+    it('should call log() with correct params (with customProperties)', () => {
+      spy = jest.spyOn(perfume, 'log');
+      perfume.config.logging = true;
+      perfume.start('metricName');
+      perfume.end('metricName', { page: '/login' });
+      expect(spy.mock.calls.length).toEqual(1);
+      expect(spy).toHaveBeenCalledWith('metricName', 12346, { page: '/login' });
     });
   });
 
@@ -257,7 +266,19 @@ describe('Perfume', () => {
       spy = jest.spyOn(perfume.config, 'analyticsTracker');
       (perfume as any).sendTiming('metricName', 123);
       expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith('metricName', 123, undefined);
+      expect(spy).toHaveBeenCalledWith('metricName', 123, undefined, undefined);
+    });
+
+    it('should call analyticsTracker() with customProperties, if defined', () => {
+      perfume.config.analyticsTracker = (metricName, duration) => {
+        // console.log(metricName, duration);
+      };
+      spy = jest.spyOn(perfume.config, 'analyticsTracker');
+      (perfume as any).sendTiming('metricName', 123, { page: '/login' });
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith('metricName', 123, undefined, {
+        page: '/login',
+      });
     });
 
     it('should not call global.logWarn() if googleAnalytics is disable', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfume.js-fork",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "JavaScript library that measures First (Contentful) Paint (FP/FCP) and First Input Delay (FID). Annotates components’ performance for Vanilla and Angular applications, into the DevTools timeline. Reports all the results to Google Analytics or your favorite tracking tool.",
   "keywords": [
     "performance-metrics",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "perfume.js",
-  "version": "2.1.2",
+  "name": "perfume.js-fork",
+  "version": "0.0.1",
   "description": "JavaScript library that measures First (Contentful) Paint (FP/FCP) and First Input Delay (FID). Annotates components’ performance for Vanilla and Angular applications, into the DevTools timeline. Reports all the results to Google Analytics or your favorite tracking tool.",
   "keywords": [
     "performance-metrics",


### PR DESCRIPTION
This PR addresses issue https://github.com/Zizzamia/perfume.js/issues/68, by providing a way to log custom properties from within Perfume

