### PR TITLE
feat: replace Map by plain old objects to support more browsers

### DIFF
--- a/__tests__/perfume.spec.ts
+++ b/__tests__/perfume.spec.ts
@@ -12,8 +12,8 @@ describe('Perfume', () => {
     (window as any).PerformanceObserver = mock.PerformanceObserver;
     (window as any).console.log = (n: any) => n;
     (window as any).console.warn = (n: any) => n;
-    perfume['observers'].set('fcp', () => 400);
-    perfume['observers'].set('fid', () => 400);
+    perfume['observers']['fcp'] = () => 400;
+    perfume['observers']['fid'] = () => 400;
     perfume['queue'].pushTask = (cb: any) => cb();
   });
 
@@ -56,7 +56,7 @@ describe('Perfume', () => {
         firstContentfulPaint: false,
         firstInputDelay: true,
       });
-      perfume['observers'].set('fid', () => 400);
+      perfume['observers']['fid'] = () => 400;
       perfume['queue'].pushTask = (cb: any) => cb();
     });
 

--- a/__tests__/perfume.spec.ts
+++ b/__tests__/perfume.spec.ts
@@ -136,6 +136,17 @@ describe('Perfume', () => {
       expect(spy.mock.calls.length).toEqual(1);
       expect(spy).toHaveBeenCalledWith('metricName', 12346);
     });
+
+    it('should delete metrics properly', () => {
+      perfume = new Perfume({
+        firstPaint: false,
+        firstContentfulPaint: true,
+        firstInputDelay: true,
+      });
+      perfume.start('firstInputDelay');
+      perfume.end('firstInputDelay');
+      expect(perfume['metrics'].firstInputDelay).not.toBeDefined();
+    });
   });
 
   describe('.start() and .end()', () => {

--- a/src/idle-queue.ts
+++ b/src/idle-queue.ts
@@ -95,6 +95,15 @@ export const cIC = supportsRequestIdleCallback_
   ? window.cancelIdleCallback
   : cancelIdleCallbackShim;
 
+const supportsPromisesNatively: boolean =
+  typeof Promise === 'function' &&
+  Promise.toString().indexOf('[native code]') > -1;
+
+const supportsMutationObserver: boolean =
+  'MutationObserver' in window ||
+  'WebKitMutationObserver' in window ||
+  'MozMutationObserver' in window;
+
 /*
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
@@ -142,6 +151,10 @@ const createQueueMicrotaskViaMutationObserver = () => {
   };
 };
 
+const discardMicrotasks = () => {
+  return (microtask: any) => {};
+};
+
 /**
  * Queues a function to be run in the next microtask. If the browser supports
  * Promises, those are used. Otherwise it falls back to MutationObserver.
@@ -150,11 +163,11 @@ const createQueueMicrotaskViaMutationObserver = () => {
  * @private
  * @param {!Function} microtask
  */
-export const queueMicrotask =
-  typeof Promise === 'function' &&
-  Promise.toString().indexOf('[native code]') > -1
-    ? createQueueMicrotaskViaPromises()
-    : createQueueMicrotaskViaMutationObserver();
+export const queueMicrotask = supportsPromisesNatively
+  ? createQueueMicrotaskViaPromises()
+  : supportsMutationObserver
+    ? createQueueMicrotaskViaMutationObserver()
+    : discardMicrotasks();
 
 const DEFAULT_MIN_TASK_TIME = 0;
 

--- a/src/idle-queue.ts
+++ b/src/idle-queue.ts
@@ -95,15 +95,6 @@ export const cIC = supportsRequestIdleCallback_
   ? window.cancelIdleCallback
   : cancelIdleCallbackShim;
 
-const supportsPromisesNatively: boolean =
-  typeof Promise === 'function' &&
-  Promise.toString().indexOf('[native code]') > -1;
-
-const supportsMutationObserver: boolean =
-  'MutationObserver' in window ||
-  'WebKitMutationObserver' in window ||
-  'MozMutationObserver' in window;
-
 /*
  * Copyright 2018 Google Inc. All Rights Reserved.
  *
@@ -151,10 +142,6 @@ const createQueueMicrotaskViaMutationObserver = () => {
   };
 };
 
-const discardMicrotasks = () => {
-  return (microtask: any) => {};
-};
-
 /**
  * Queues a function to be run in the next microtask. If the browser supports
  * Promises, those are used. Otherwise it falls back to MutationObserver.
@@ -163,11 +150,11 @@ const discardMicrotasks = () => {
  * @private
  * @param {!Function} microtask
  */
-export const queueMicrotask = supportsPromisesNatively
-  ? createQueueMicrotaskViaPromises()
-  : supportsMutationObserver
-    ? createQueueMicrotaskViaMutationObserver()
-    : discardMicrotasks();
+export const queueMicrotask =
+  typeof Promise === 'function' &&
+  Promise.toString().indexOf('[native code]') > -1
+    ? createQueueMicrotaskViaPromises()
+    : createQueueMicrotaskViaMutationObserver();
 
 const DEFAULT_MIN_TASK_TIME = 0;
 

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -206,7 +206,7 @@ export default class Perfume {
     // Get duration and change it to a two decimal value
     const duration = this.perf.measure(metricName, metric);
     const duration2Decimal = parseFloat(duration.toFixed(2));
-    delete this.metrics.metricName;
+    delete this.metrics[metricName];
     this.queue.pushTask(() => {
       // Log to console, delete metric and send to analytics tracker
       this.log(metricName, duration2Decimal);

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -172,7 +172,7 @@ export default class Perfume {
     if (!this.checkMetricName(metricName)) {
       return;
     }
-    if (this.metrics.hasOwnProperty(metricName)) {
+    if (this.metrics[metricName]) {
       this.logWarn(this.config.logPrefix, 'Recording already started.');
       return;
     }

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -64,6 +64,14 @@ export interface IMetricEntry {
   end: number;
 }
 
+export interface IMetricMap {
+  [metricName: string]: IMetricEntry;
+}
+
+export interface IObserverMap {
+  [metricName: string]: any;
+}
+
 export declare interface IPerformanceEntry {
   duration: number;
   entryType: 'longtask' | 'measure' | 'navigation' | 'paint' | 'resource';
@@ -106,8 +114,8 @@ export default class Perfume {
   private isHidden: boolean = false;
   private logMetricWarn = 'Please provide a metric name';
   private queue: any;
-  private metrics: Map<string, IMetricEntry> = new Map();
-  private observers = new Map();
+  private metrics: IMetricMap = {};
+  private observers: IObserverMap = {};
   private perf: Performance | EmulatedPerformance;
   private perfEmulated?: EmulatedPerformance;
 
@@ -134,7 +142,7 @@ export default class Perfume {
     if (this.config.firstPaint || this.config.firstContentfulPaint) {
       this.observeFirstContentfulPaint = new Promise(resolve => {
         this.logDebug('observeFirstContentfulPaint');
-        this.observers.set('fcp', resolve);
+        this.observers['fcp'] = resolve;
         this.initFirstPaint();
       });
     }
@@ -143,7 +151,7 @@ export default class Perfume {
     // a Promise that can be observed
     if (this.config.firstInputDelay) {
       this.observeFirstInputDelay = new Promise(resolve => {
-        this.observers.set('fid', resolve);
+        this.observers.fid = resolve;
         this.initFirstInputDelay();
       });
     }
@@ -164,14 +172,14 @@ export default class Perfume {
     if (!this.checkMetricName(metricName)) {
       return;
     }
-    if (this.metrics.has(metricName)) {
+    if (this.metrics.hasOwnProperty(metricName)) {
       this.logWarn(this.config.logPrefix, 'Recording already started.');
       return;
     }
-    this.metrics.set(metricName, {
+    this.metrics[metricName] = {
       end: 0,
       start: this.perf.now(),
-    });
+    };
 
     // Creates a timestamp in the browser's performance entry buffer
     this.perf.mark(metricName, 'start');
@@ -187,7 +195,7 @@ export default class Perfume {
     if (!this.checkMetricName(metricName)) {
       return;
     }
-    const metric = this.metrics.get(metricName);
+    const metric = this.metrics[metricName];
     if (!metric) {
       this.logWarn(this.config.logPrefix, 'Recording already stopped.');
       return;
@@ -198,7 +206,7 @@ export default class Perfume {
     // Get duration and change it to a two decimal value
     const duration = this.perf.measure(metricName, metric);
     const duration2Decimal = parseFloat(duration.toFixed(2));
-    this.metrics.delete(metricName);
+    delete this.metrics.metricName;
     this.queue.pushTask(() => {
       // Log to console, delete metric and send to analytics tracker
       this.log(metricName, duration2Decimal);
@@ -411,11 +419,11 @@ export default class Perfume {
     }
     if (metricName === 'firstContentfulPaint') {
       this.firstContentfulPaintDuration = duration2Decimal;
-      this.observers.get('fcp')(duration2Decimal);
+      this.observers['fcp'](duration2Decimal);
     }
     if (metricName === 'firstInputDelay') {
       this.firstInputDelayDuration = duration2Decimal;
-      this.observers.get('fid')(duration2Decimal);
+      this.observers['fid'](duration2Decimal);
     }
 
     // Logs the metric in the internal console.log


### PR DESCRIPTION
Since we use basic Map features (get, set, has, delete) only, we can
as well just replace our maps by objects to support IE < 11 and other
browser that do not recognize ES6 specifications.
This keeps the bundle small and avoids the need of costly polyfills. We, the performance measurement teams, have a special interest in keeping our performance impact as low as possible.