### PR TITLE
fix: restore UMD module breaking

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -62,6 +62,7 @@ const createConfig = ({ output, min = false }) => {
             'workerStart',
             'transferSize',
             'encodedBodySize',
+            'Perfume',
           ]
         }
       },


### PR DESCRIPTION
TL;DR: The extreme minification removes even the ".Perfume=" part that is essential to get the UMD module working if loaded from a CDN. Without this fix, `Perfume` is `undefined` in a page that loads the UMD version through a CDN.

My [Perfume.js for Gatsby plugin](https://github.com/NoriSte/gatsby-plugin-perfume.js) cannot update Perfume.js to the latest version. That's because of a failing test, the one that checks that Perfume.js could be consumed through Unpkg (instead of installing/importing in the local project). [Here the option](https://github.com/NoriSte/gatsby-plugin-perfume.js/blob/master/test-projects/non-inline-perfume-test/gatsby-config.js#L43) and [here the option management](https://github.com/NoriSte/gatsby-plugin-perfume.js/blob/master/src/gatsby-ssr.js#L41-L42).
The test fails because the [previous version](https://unpkg.com/perfume.js@3.0.3/dist/perfume.umd.min.js)(line 1, column 155) has a `Perfume=` code that it is disappeared in the [new version](https://unpkg.com/perfume.js@4.5.0/dist/perfume.umd.min.js) (that makes the global scope "dirty" with a `t` variable).

@Zizzamia suggested me how to solve it, I have tested it locally and I can confirm that everything works with this change.

This way I could update my Gatsby plugin to leverage the latest Perfume.js version 😊