### PR TITLE
docs: Perfume JS should be installed as a dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ With Perfume.js, you can collect those metrics and have a deep understanding eve
 
 npm (https://www.npmjs.com/package/perfume.js):
 
-    npm install perfume.js --save-dev
+    npm install perfume.js --save
 
 ### Importing library
 


### PR DESCRIPTION
Correcting the installation option ( replacing '--save-dev' with '--save' ).