### PR TITLE
[docs] Perfume.js should be installed as a dependency (not dev-dependency)

### DIFF
--- a/docs/src/app/app.component.html
+++ b/docs/src/app/app.component.html
@@ -70,7 +70,7 @@
             <tr>
               <td class="code">
                 <pre><span class="gray">// Install</span>
-npm install perfume.js --save-dev
+npm install perfume.js --save
 
 <span class="gray">// Importing library</span>
 <span class="gray">// Import the generated bundle to use the whole library generated:</span>


### PR DESCRIPTION
Resolves https://github.com/Zizzamia/perfume.js/issues/101

This change updates the example for "[Installing and Imports](https://zizzamia.github.io/perfume/#/installing-and-imports/)"