### PR TITLE
feat: added generateTrackerData to simplify options conversion

### DIFF
--- a/src/generateTrackerData.ts
+++ b/src/generateTrackerData.ts
@@ -1,34 +1,56 @@
-import { IAnalyticsTrackerOptions } from './types';
+import {
+  IPerfumeData,
+  IAnalyticsTrackerOptions,
+  IPerfumeNavigationTiming,
+  IPerfumeNetworkInformation,
+} from './types';
 
-export const generateTrackerData = (
-  options: IAnalyticsTrackerOptions,
-): { metricName: string; duration?: number; value?: any } => {
+export const generateTrackerData = (options: IAnalyticsTrackerOptions) => {
+  const isIPerfumeDataType = <T extends IPerfumeData>(
+    iPerfumeData: IPerfumeData,
+  ): iPerfumeData is T => {
+    const data = iPerfumeData as T;
+    if (typeof iPerfumeData !== 'object') return false;
+
+    const dataKeys = Object.keys(data) as (keyof T)[];
+    for (const key of dataKeys) if (data[key] !== undefined) return true;
+    return false;
+  };
+
   const { metricName, data } = options;
   switch (metricName) {
     case 'navigationTiming':
-      if (data && data.timeToFirstByte) {
-        return { metricName: 'navigationTiming', duration: data };
+      if (
+        data &&
+        isIPerfumeDataType<IPerfumeNavigationTiming>(data) &&
+        data.timeToFirstByte
+      ) {
+        return { metricName: 'navigationTiming', data };
       }
       break;
     case 'networkInformation':
-      if (data && data.effectiveType) {
-        return { metricName: 'networkInformation', duration: data };
+      if (
+        data &&
+        isIPerfumeDataType<IPerfumeNetworkInformation>(data) &&
+        data.effectiveType
+      ) {
+        return { metricName: 'networkInformation', data };
       }
       break;
     case 'storageEstimate':
-      return { metricName: 'storageEstimate', duration: data };
+      return { metricName: 'storageEstimate', data };
       break;
     case 'fp':
-      return { metricName: 'firstPaint', duration: data.duration };
+      return { metricName: 'firstPaint', duration: data };
       break;
     case 'fcp':
-      return { metricName: 'firstContentfulPaint', duration: data.duration };
+      return { metricName: 'firstContentfulPaint', duration: data };
       break;
     case 'fid':
-      return { metricName: 'firstInputDelay', duration: data.duration };
+      return { metricName: 'firstInputDelay', duration: data };
       break;
     case 'lcp':
-      return { metricName: 'largestContentfulPaint', duration: data.duration };
+      return { metricName: 'largestContentfulPaint', duration: data };
       break;
     case 'lcpFinal':
       return { metricName: 'largestContentfulPaintFinal', duration: data };
@@ -40,21 +62,19 @@ export const generateTrackerData = (
       return { metricName: 'cumulativeLayoutShiftFinal', value: data };
       break;
     case 'tbt':
-      return { metricName: 'totalBlockingTime', duration: data.duration };
+      return { metricName: 'totalBlockingTime', duration: data };
       break;
     case 'tbt5S':
-      return { metricName: 'totalBlockingTime5S', duration: data.duration };
+      return { metricName: 'totalBlockingTime5S', duration: data };
       break;
     case 'tbt10S':
-      return { metricName: 'totalBlockingTime10S', duration: data.duration };
+      return { metricName: 'totalBlockingTime10S', duration: data };
       break;
     case 'tbtFinal':
-      return { metricName: 'totalBlockingTimeFinal', duration: data.duration };
+      return { metricName: 'totalBlockingTimeFinal', duration: data };
       break;
     default:
-      return { metricName, duration: data.duration };
+      return { metricName: metricName, duration: data };
       break;
   }
-
-  return { metricName, duration: data.duration };
 };

--- a/src/generateTrackerData.ts
+++ b/src/generateTrackerData.ts
@@ -1,0 +1,60 @@
+import { IAnalyticsTrackerOptions } from './types';
+
+export const generateTrackerData = (
+  options: IAnalyticsTrackerOptions,
+): { metricName: string; duration?: number; value?: any } => {
+  const { metricName, data } = options;
+  switch (metricName) {
+    case 'navigationTiming':
+      if (data && data.timeToFirstByte) {
+        return { metricName: 'navigationTiming', duration: data };
+      }
+      break;
+    case 'networkInformation':
+      if (data && data.effectiveType) {
+        return { metricName: 'networkInformation', duration: data };
+      }
+      break;
+    case 'storageEstimate':
+      return { metricName: 'storageEstimate', duration: data };
+      break;
+    case 'fp':
+      return { metricName: 'firstPaint', duration: data.duration };
+      break;
+    case 'fcp':
+      return { metricName: 'firstContentfulPaint', duration: data.duration };
+      break;
+    case 'fid':
+      return { metricName: 'firstInputDelay', duration: data.duration };
+      break;
+    case 'lcp':
+      return { metricName: 'largestContentfulPaint', duration: data.duration };
+      break;
+    case 'lcpFinal':
+      return { metricName: 'largestContentfulPaintFinal', duration: data };
+      break;
+    case 'cls':
+      return { metricName: 'cumulativeLayoutShift', value: data };
+      break;
+    case 'clsFinal':
+      return { metricName: 'cumulativeLayoutShiftFinal', value: data };
+      break;
+    case 'tbt':
+      return { metricName: 'totalBlockingTime', duration: data.duration };
+      break;
+    case 'tbt5S':
+      return { metricName: 'totalBlockingTime5S', duration: data.duration };
+      break;
+    case 'tbt10S':
+      return { metricName: 'totalBlockingTime10S', duration: data.duration };
+      break;
+    case 'tbtFinal':
+      return { metricName: 'totalBlockingTimeFinal', duration: data.duration };
+      break;
+    default:
+      return { metricName, duration: data.duration };
+      break;
+  }
+
+  return { metricName, duration: data.duration };
+};


### PR DESCRIPTION
The v5 docs reported a big `switch` that every Perfume.js consumer must copy/paste to correctly track Perfume.js data.

I'd like to update my [gatsby-plugin-perfume](https://github.com/NoriSte/gatsby-plugin-perfume.js) package but I'd like to avoid mapping the tracker options in my code in order to ease new future options adding.

To do so I propose to add a new `generateTrackerData` factory that allows plugin developers to leverage it instead of copy/pasting the switch. The factory is not included by any file so it could be consumed by the developer without affecting the build size.

Please note that, according to the main `types.ts` files, the `generateTrackerData` return data is full of generics and does not allow a really strict type checking. I suggest to properly typing the 

```ts
export interface IAnalyticsTrackerOptions {
  metricName: string;
  data?: any;
  duration?: number;
  eventProperties?: object;
  navigatorInformation?: INavigatorInfo;
}
```
object leveraging a discriminated union (using `metricName` as the key) instead of a lot of generics but this is out of the scope of this PR.