### PR TITLE
Update First Content Paint thresholds to match web.dev guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Perfume is a tiny, web performance monitoring library that reports field data ba
 - [Web Vitals Score](https://web.dev/vitals/)
 
 <br />
-With Perfume.js, you can collect these metrics to develop a deeper understanding of how customers around the world perceive web performance for your application. 
+With Perfume.js, you can collect these metrics to develop a deeper understanding of how customers around the world perceive web performance for your application.
 <br />
-Use your favorite analytics tool to visualize the data from country to country. 
+Use your favorite analytics tool to visualize the data from country to country.
 Take a look at this example comparing <b>FCP</b> for www.coinbase.com in the United States, Italy, Indonesia, and Nigeria.
 <br />
 
@@ -327,7 +327,7 @@ Perfume will expose for all major metrics the vitals score, those can be used to
 | Web Vitals                                |   Good | Needs Improvement |      Poor |
 | ----------------------------------------- | -----: | ----------------: | --------: |
 | Fist Paint (fp)                           | 0-1000 |         1001-2500 | Over 2500 |
-| First Contentful Paint (fcp)              | 0-1000 |         1001-2500 | Over 2500 |
+| First Contentful Paint (fcp)              | 0-2000 |         2001-4000 | Over 4000 |
 | Largest Contentful Paint (lcp)            | 0-2500 |         2501-4000 | Over 4000 |
 | Largest Contentful Paint Final (lcpFinal) | 0-2500 |         2501-4000 | Over 4000 |
 | First Input Delay (fid)                   |  0-100 |           101-300 |  Over 300 |

--- a/__tests__/vitalsScore.spec.ts
+++ b/__tests__/vitalsScore.spec.ts
@@ -6,8 +6,8 @@ describe('vitalsScore', () => {
   describe('webVitalsScore', () => {
     it('should default to the correct values', () => {
       expect(webVitalsScore).toEqual({
-        fp: [1000, 2500],
-        fcp: [1000, 2500],
+        fp: [2000, 4000],
+        fcp: [2000, 4000],
         lcp: [2500, 4000],
         lcpFinal: [2500, 4000],
         fid: [100, 300],
@@ -25,8 +25,8 @@ describe('vitalsScore', () => {
   describe('.getVitalsScore()', () => {
     it('should return the correct values for fcp', () => {
       expect(getVitalsScore('fcp', 200)).toEqual('good');
-      expect(getVitalsScore('fcp', 1200)).toEqual('needsImprovement');
-      expect(getVitalsScore('fcp', 3200)).toEqual('poor');
+      expect(getVitalsScore('fcp', 2200)).toEqual('needsImprovement');
+      expect(getVitalsScore('fcp', 4200)).toEqual('poor');
     });
 
     it('should return the correct values for lcp', () => {

--- a/src/vitalsScore.ts
+++ b/src/vitalsScore.ts
@@ -1,6 +1,6 @@
 import { IPerfumeData, IVitalsScore } from './types';
 
-const fcpScore = [1000, 2500];
+const fcpScore = [2000, 4000];
 const lcpScore = [2500, 4000];
 const fidcore = [100, 300];
 const clsScore = [0.1, 0.25];


### PR DESCRIPTION
The First Content Paint guidelines for the good/ok/bad buckets on [web.dev](https://web.dev/first-contentful-paint/) differ from what was being calculated internally. The current thresholds are

0s - 1s: Good
1s - 2.5s: Ok
2.5s+: Bad

Whereas the current recommendations for tools like Lighthouse use the following

0s - 2s: Good
2s - 4s: Ok
4s+ Bad

This PR syncs up the thresholds for First Content Paint to keep in line with what Lighthouse recommends. 

We should wait until the end of this week with Google I/O to see if any other adjustments are made before we merge this so we can keep things in sync with the best practices for all performance metrics.