### PR TITLE
docs: Remove the Gatsby plugin

### DIFF
--- a/README-it.md
+++ b/README-it.md
@@ -442,7 +442,6 @@ Per connetterti con altri analytics providers, controlla il [analytics plugin fo
 
 ## Plugins
 
-- [Perfume.js plugin for GatsbyJS](https://github.com/NoriSte/gatsby-plugin-perfume.js)
 - [Perfume.js plugin for Analytics](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-perfumejs)
   <br />
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -373,7 +373,6 @@ Additional analytics providers와 연결하려면 이 링크를 참고해주세�
 
 ## Plugins
 
-- [Perfume.js plugin for GatsbyJS](https://github.com/NoriSte/gatsby-plugin-perfume.js)
 - [Perfume.js plugin for Analytics](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-perfumejs)
   <br />
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -376,7 +376,6 @@ new Perfume({
 
 ## 插件
 
-- [Perfume.js plugin for GatsbyJS](https://github.com/NoriSte/gatsby-plugin-perfume.js)
 - [Perfume.js plugin for Analytics](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-perfumejs)
   <br />
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ initPerfume({
       case 'elPageTitle':
         myAnalyticsTool.track('elementTimingPageTitle', { duration: data });
         break;
-      case 'userJourneyStep': 
+      case 'userJourneyStep':
         myAnalyticsTool.track('userJourneyStep', {
           duration: data,
           stepName: attribution.step_name,
@@ -402,7 +402,7 @@ In order for Perfume to be able to track metrics for Steps, we need to configure
 
 Below you can find an example of how to do this.
 
-``` typescript 
+``` typescript
 export const steps = {
   load_screen_A: {
     threshold: ThresholdTier.quick,
@@ -416,7 +416,7 @@ export const steps = {
 
 initPerfume({ steps });
 
-``` 
+```
 
 #### MarkStep
 `markStep` is the function used to start and end steps in applications.
@@ -425,15 +425,15 @@ For example, if we wanted to mark the beginning of load_screen_B step above, we 
 
 #### `enableNavigationTracking`
 
-`enableNavigationTracking` is a boolean in the config that will tell Perfume to take into account page navigation changes or not. By default this is `true`, but it can be set to false if needed. 
+`enableNavigationTracking` is a boolean in the config that will tell Perfume to take into account page navigation changes or not. By default this is `true`, but it can be set to false if needed.
 
-The purpose of this feature is to only account for active steps that the user is working on. The feature will remove any inactive or 'stale' steps that are not currently in progress. 
+The purpose of this feature is to only account for active steps that the user is working on. The feature will remove any inactive or 'stale' steps that are not currently in progress.
 
-Stale steps can be created by navigating away from a page before it fully loads, this would cause the start mark to be triggered, but the end mark to not be called. This would affect the `active` steps being returned to `onMarkStep` as well as would create incorrect data if we returned back to the end mark much later than expected. 
+Stale steps can be created by navigating away from a page before it fully loads, this would cause the start mark to be triggered, but the end mark to not be called. This would affect the `active` steps being returned to `onMarkStep` as well as would create incorrect data if we returned back to the end mark much later than expected.
 
 `enableNavigationTracking` works together with the `incrementUjNavigation` function. The `incrementUjNavigation` function is to be called anytime there is a navigation change in your application. Below is an example for how this would work in a React Application:
 
-``` typescript 
+``` typescript
 import { useLocation } from 'react-router-dom';
 
 const MyComponent = () => {
@@ -446,7 +446,7 @@ const MyComponent = () => {
   ...
 }
 
-``` 
+```
 
 ## Web Vitals Score
 
@@ -529,7 +529,6 @@ To connect with additional analytics providers, checkout the [analytics plugin f
 
 ## Plugins
 
-- [Perfume.js plugin for GatsbyJS](https://github.com/NoriSte/gatsby-plugin-perfume.js)
 - [Perfume.js plugin for Analytics](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-perfumejs)
   <br />
 


### PR DESCRIPTION
See https://github.com/NoriSte/gatsby-plugin-perfume.js/issues/409 for more info about the deprecation choice and hence the removal from the docs included in this PR 😊