### PR TITLE
Added test coverage for User Journey Test Tracking 

### DIFF
--- a/__tests__/steps/markJourney.spec.ts
+++ b/__tests__/steps/markJourney.spec.ts
@@ -4,16 +4,18 @@
 import { WP } from '../../src/constants';
 import mock from '../_mock';
 import { initPerfume } from '../../src/initPerfume';
-import { markStep } from '../../src/steps/markStep';
+import { markStep, end } from '../../src/steps/markStep';
 import { steps } from '../../src/steps/steps';
 
-import { testConfig } from '../stepsTestConstants';
+import { testConfig, navigationTestConfig } from '../stepsTestConstants';
+import { config } from '../../src/config';
 
 describe('markStep', () => {
   let spy: jest.SpyInstance;
 
   beforeEach(() => {
     (WP as any) = mock.performance();
+    (window as any).PerformanceObserver = mock.PerformanceObserver;
     initPerfume(testConfig);
   });
 
@@ -45,5 +47,15 @@ describe('markStep', () => {
         'mark.start_navigate_to_second_screen_first_journey',
       );
     });
+    it('shouldnt mark anything if performance is not supported', () => { 
+      spy = jest.spyOn(WP, 'mark');
+      // @ts-ignore
+      delete window.performance.mark;
+      markStep('start_navigate_to_second_screen_first_journey');
+      expect(spy.mock.calls.length).toBe(0);
+      end('test');
+      expect(spy.mock.calls.length).toBe(0);
+    })
+    
   });
 });

--- a/__tests__/steps/measureStep.spec.ts
+++ b/__tests__/steps/measureStep.spec.ts
@@ -8,6 +8,7 @@ import { markStep } from '../../src/steps/markStep';
 import { config } from '../../src/config';
 
 import { testConfig } from '../stepsTestConstants';
+import { measureStep } from '../../src/steps/measureStep';
 
 describe('measureStep', () => {
   let spy: jest.SpyInstance;
@@ -138,5 +139,14 @@ describe('measureStep', () => {
         },
       });
     });
+    it('should return when the start mark doesnt exist', () => { 
+      measureSpy = jest.spyOn(WP, 'measure');
+      // ============ Mock Data ============
+      jest.spyOn(WP, 'getEntriesByName').mockImplementationOnce(name => {
+        return [];
+      });
+      measureStep('not-valid-step', 'startMark', 'endmark');
+      expect(measureSpy).toBeCalledTimes(0);
+    })
   });
 });

--- a/__tests__/steps/navSteps.spec.ts
+++ b/__tests__/steps/navSteps.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/steps/navigationSteps';
 
 import { navigationTestConfig } from '../stepsTestConstants';
+import { config } from '../../src/config';
 
 describe('navSteps', () => {
   let spy: jest.SpyInstance;
@@ -65,6 +66,16 @@ describe('navSteps', () => {
     it('returns and empty list if there are not navigations steps recorded', () => {
       expect(getActiveStepsFromNavigationSteps()).toEqual({});
     });
+
+    it('it should run the navigationbased active steps', () => { 
+      config.onMarkStep = () => {};
+      spy = jest.spyOn(config, 'onMarkStep');
+      markStep('start_navigate_to_second_screen_first_journey');
+      expect(spy).toHaveBeenCalledWith(
+        'start_navigate_to_second_screen_first_journey',
+        ['load_second_screen_first_journey'],
+      );
+    })
 
     it('returns load_home_screen as an active step', () => {
       markStep('start_navigate_to_second_screen_first_journey');
@@ -149,6 +160,20 @@ describe('navSteps', () => {
         load_fourth_screen_first_journey: true,
         load_third_screen_first_journey: true,
       });
+
+      // closing most recent step
+      markStep('loaded_third_screen_first_journey');
+
+      expect(getActiveStepsFromNavigationSteps()).toEqual({
+        load_fourth_screen_first_journey: true,
+        load_third_screen_first_journey: true,
+      });
     });
+
+    it('departs endmark if theres no start mark', () => { 
+      markStep('loaded_third_screen_first_journey');
+      // never encountered a start mark so nothing is active
+      expect(getActiveStepsFromNavigationSteps()).toEqual({});
+    })
   });
 });

--- a/__tests__/steps/setStepsMap.spec.ts
+++ b/__tests__/steps/setStepsMap.spec.ts
@@ -5,6 +5,7 @@ import { WP } from '../../src/constants';
 import mock from '../_mock';
 import { initPerfume } from '../../src/initPerfume';
 import { steps } from '../../src/steps/steps';
+import { setStepsMap } from '../../src/steps/setStepsMap';
 
 import { testConfig } from '../stepsTestConstants';
 
@@ -85,5 +86,12 @@ describe('setSteps', () => {
         },
       });
     });
+
+    it('returns when no steps are provided', () => { 
+      initPerfume({});
+      setStepsMap();
+      expect(steps.finalMarkToStepsMap).toMatchObject({});
+      expect(steps.finalMarkToStepsMap).toMatchObject({});
+    })
   });
 });

--- a/__tests__/stepsTestConstants.ts
+++ b/__tests__/stepsTestConstants.ts
@@ -99,6 +99,7 @@ export const testConfig: IPerfumeOptions = {
 export const navigationTestConfig: IPerfumeOptions = {
   steps,
   onMarkStep: jest.fn(),
+  enableNavigationTracking: true,
 };
 
 export type TestConfig = IPerfumeConfig;

--- a/src/steps/measureStep.ts
+++ b/src/steps/measureStep.ts
@@ -12,16 +12,13 @@ export const measureStep = (
   const stepMetricName = S + step;
   const startMarkExists = WP.getEntriesByName(M + startMark).length > 0;
   const endMarkExists = WP.getEntriesByName(M + endMark).length > 0;
-  if (!endMarkExists || !config.steps) {
+  if (!endMarkExists || !startMarkExists || !config.steps || !config.steps[step]) {
     return;
   }
 
   const { maxOutlierThreshold, vitalsThresholds } =
     STEP_THRESHOLDS[config.steps[step].threshold];
 
-  if (!startMarkExists) {
-    return;
-  }
   const stepMeasure = WP.measure(stepMetricName, M + startMark, M + endMark);
   const { duration } = stepMeasure;
   if (duration <= maxOutlierThreshold) {

--- a/src/steps/measureSteps.ts
+++ b/src/steps/measureSteps.ts
@@ -17,9 +17,9 @@ export const measureSteps = (mark: string) => {
       const possibleSteps = finalSteps[startMark];
       possibleSteps.forEach(removeActiveStep);
       Promise.all(
-        possibleSteps.map(async step => {
+        possibleSteps.map(step => {
           // measure
-          await measureStep(step, startMark, mark);
+          measureStep(step, startMark, mark);
         }),
       ).catch(() => {
         // TODO @zizzamia log error


### PR DESCRIPTION
Added new test coverage for User Journey tracking to being all files to 95% coverage 

(markStep.ts that has 94% coverage contains endPaint that is going to be deprecated in the next version) 

![Screenshot 2023-06-27 at 8 56 06 AM](https://github.com/Zizzamia/perfume.js/assets/50121662/6a828a8e-0167-49b9-a766-130c429d5f5f)
