### PR TITLE
Deprecate 'endPaint' 

### DIFF
--- a/__tests__/steps/markStep.spec.ts
+++ b/__tests__/steps/markStep.spec.ts
@@ -7,7 +7,7 @@ import * as log from '../../src/log';
 import { metrics } from '../../src/metrics';
 import * as observe from '../../src/observe';
 import { visibility } from '../../src/onVisibilityChange';
-import { clear, end, endPaint, start } from '../../src/steps/markStep';
+import { clear, end, start } from '../../src/steps/markStep';
 import mock from './../_mock';
 
 describe('Perfume', () => {
@@ -80,20 +80,6 @@ describe('Perfume', () => {
       expect(metrics['metricName']).not.toBeDefined();
     });
   });
-
-  // TODO Fix this test or just deprecate by deprecating end()
-  //describe('endPaint()', () => {
-  //  beforeEach(() => {
-  //    jest.useFakeTimers();
-  //  });
-  //
-  //  it('should call end() after the first setTimeout', () => {
-  //    spy = jest.spyOn(perfume, 'end');
-  //    endPaint('test');
-  //    jest.runAllTimers();
-  //    expect(spy.mock.calls.length).toEqual(1);
-  //  });
-  //});
 
   describe('clear()', () => {
     beforeEach(() => {

--- a/src/perfume.ts
+++ b/src/perfume.ts
@@ -1,16 +1,7 @@
 import { initPerfume } from './initPerfume';
 
-import { clear, end, endPaint, markStep, start } from './steps/markStep';
+import { clear, markStep } from './steps/markStep';
 import { markStepOnce } from './steps/markStepOnce';
 import { trackUJNavigation } from './steps/navigationSteps';
 
-export {
-  clear,
-  end,
-  endPaint,
-  initPerfume,
-  markStep,
-  markStepOnce,
-  trackUJNavigation,
-  start,
-};
+export { clear, initPerfume, markStep, markStepOnce, trackUJNavigation };

--- a/src/steps/markStep.ts
+++ b/src/steps/markStep.ts
@@ -24,7 +24,7 @@ export const markStep = (mark: string) => {
 };
 
 // --------------------- TMP Location Before Deprecation -----------------
-// For start(), end(), endPaint(), clear()
+// For start(), end(), clear()
 
 /**
  * Start performance measurement
@@ -52,15 +52,6 @@ export const start = (markName: string): void => {
   if (doLogData) {
     logData(markName, roundByFour(measure), customProperties);
   }
-}
-
-/**
- * End performance measurement after first paint from the beging of it
- */
- export const endPaint = (markName: string, customProperties?: object): void => {
-  setTimeout(() => {
-    end(markName, customProperties);
-  });
 }
 
 /**


### PR DESCRIPTION
This PR deprecates 'endPaint' and removes the 'start' and 'end' api.