### PR TITLE
Added extra check for undefined values

### DIFF
--- a/__tests__/steps/measureStep.spec.ts
+++ b/__tests__/steps/measureStep.spec.ts
@@ -139,7 +139,7 @@ describe('measureStep', () => {
         },
       });
     });
-    it('should return when the start mark doesnt exist', () => { 
+    it('should return when the start mark doesnt exist', () => {
       measureSpy = jest.spyOn(WP, 'measure');
       // ============ Mock Data ============
       jest.spyOn(WP, 'getEntriesByName').mockImplementationOnce(name => {
@@ -147,6 +147,36 @@ describe('measureStep', () => {
       });
       measureStep('not-valid-step', 'startMark', 'endmark');
       expect(measureSpy).toBeCalledTimes(0);
-    })
+    });
+
+    it('should return when the start mark doesnt exist', () => {
+      measureSpy = jest.spyOn(WP, 'measure');
+      jest
+        .spyOn(WP, 'measure')
+        // @ts-ignore
+        .mockImplementationOnce(() => undefined);
+      // ============ Mock Data ============
+      jest.spyOn(WP, 'getEntriesByName').mockImplementationOnce(name => {
+        const entries: Record<string, PerformanceEntry> = {
+          'mark.start_navigate_to_second_screen_first_journey': {
+            name: 'mark.start_navigate_to_second_screen_first_journey',
+            entryType: 'mark',
+            duration: 0,
+            startTime: 0,
+            toJSON: jest.fn(),
+          },
+          'mark.loaded_second_screen_first_journey': {
+            name: 'mark.loaded_second_screen_first_journey',
+            entryType: 'mark',
+            duration: 0,
+            startTime: 100,
+            toJSON: jest.fn(),
+          },
+        };
+        return [entries[name]] ?? [];
+      });
+      measureStep('load_second_screen_first_journey', 'start_navigate_to_second_screen_first_journey', 'start_navigate_to_second_screen_first_journey');
+      expect(measureSpy).toBeCalledTimes(1); // after the first call that returns undefined, it exits the function and does not call measure again
+    });
   });
 });

--- a/src/steps/measureStep.ts
+++ b/src/steps/measureStep.ts
@@ -21,6 +21,7 @@ export const measureStep = (
 
   const stepMeasure = WP.measure(stepMetricName, M + startMark, M + endMark);
 
+  // checking to ensure stepMeasure is defined - it can be undefined if measure is called on a mark that has already been measured and cleared
   if(!stepMeasure){
     return;
   }

--- a/src/steps/measureStep.ts
+++ b/src/steps/measureStep.ts
@@ -20,6 +20,11 @@ export const measureStep = (
     STEP_THRESHOLDS[config.steps[step].threshold];
 
   const stepMeasure = WP.measure(stepMetricName, M + startMark, M + endMark);
+
+  if(!stepMeasure){
+    return;
+  }
+  
   const { duration } = stepMeasure;
   if (duration <= maxOutlierThreshold) {
     const score = getRating(duration, vitalsThresholds);

--- a/src/steps/measureStep.ts
+++ b/src/steps/measureStep.ts
@@ -12,7 +12,12 @@ export const measureStep = (
   const stepMetricName = S + step;
   const startMarkExists = WP.getEntriesByName(M + startMark).length > 0;
   const endMarkExists = WP.getEntriesByName(M + endMark).length > 0;
-  if (!endMarkExists || !startMarkExists || !config.steps || !config.steps[step]) {
+  if (
+    !endMarkExists ||
+    !startMarkExists ||
+    !config.steps ||
+    !config.steps[step]
+  ) {
     return;
   }
 
@@ -21,17 +26,24 @@ export const measureStep = (
 
   const stepMeasure = WP.measure(stepMetricName, M + startMark, M + endMark);
 
-  // checking to ensure stepMeasure is defined - it can be undefined if measure is called on a mark that has already been measured and cleared
-  if(!stepMeasure){
+  // checking to ensure stepMeasure is defined - it can be undefined
+  // if measure is called on a mark that has already been measured and cleared
+  if (!stepMeasure) {
     return;
   }
-  
+
   const { duration } = stepMeasure;
   if (duration <= maxOutlierThreshold) {
     const score = getRating(duration, vitalsThresholds);
     // Do not want to measure or log negative metrics
     if (duration >= 0) {
-      reportPerf('userJourneyStep', duration, score, { stepName: step }, undefined);
+      reportPerf(
+        'userJourneyStep',
+        duration,
+        score,
+        { stepName: step },
+        undefined,
+      );
       WP.measure(`step.${step}_vitals_${score}`, {
         start: stepMeasure.startTime + stepMeasure.duration,
         end: stepMeasure.startTime + stepMeasure.duration,

--- a/src/steps/measureSteps.ts
+++ b/src/steps/measureSteps.ts
@@ -17,9 +17,9 @@ export const measureSteps = (mark: string) => {
       const possibleSteps = finalSteps[startMark];
       possibleSteps.forEach(removeActiveStep);
       Promise.all(
-        possibleSteps.map(step => {
+        possibleSteps.map(async step => {
           // measure
-          measureStep(step, startMark, mark);
+          await measureStep(step, startMark, mark);
         }),
       ).catch(() => {
         // TODO @zizzamia log error

--- a/src/steps/measureSteps.ts
+++ b/src/steps/measureSteps.ts
@@ -16,6 +16,10 @@ export const measureSteps = (mark: string) => {
     Object.keys(finalSteps).forEach(startMark => {
       const possibleSteps = finalSteps[startMark];
       possibleSteps.forEach(removeActiveStep);
+      /** 
+       * Async processing all possible steps - needs to be async due to clearing previously measured steps and marks. 
+       * If we run all concurrently, there is a chance for a race condition where we are adding and deleteing the entries in WP.Performance which caused the measure to fail.
+       */
       Promise.all(
         possibleSteps.map(async step => {
           // measure

--- a/src/steps/measureSteps.ts
+++ b/src/steps/measureSteps.ts
@@ -16,10 +16,10 @@ export const measureSteps = (mark: string) => {
     Object.keys(finalSteps).forEach(startMark => {
       const possibleSteps = finalSteps[startMark];
       possibleSteps.forEach(removeActiveStep);
-      /** 
-       * Async processing all possible steps - needs to be async due to clearing previously measured steps and marks. 
-       * If we run all concurrently, there is a chance for a race condition where we are adding and deleteing the entries in WP.Performance which caused the measure to fail.
-       */
+      // Async processing all possible steps 
+      // needs to be async due to clearing previously measured steps and marks.
+      // If we run all concurrently, there is a chance for a race condition 
+      // where we are adding and deleteing the entries in WP.Performance which caused the measure to fail.
       Promise.all(
         possibleSteps.map(async step => {
           // measure


### PR DESCRIPTION
Encountered a race condition that occurred occasionally when multiple marks were being fired off at similar times, as a result the `WP.measure(stepMetricName, M + startMark, M + endMark);` would sometimes return undefined, and then cause an undefined type error. 

Added back in the async/await into calling `measureStep` and added an extra check to ensure null durations are handled

New Test Coverage - we can see the new return being tested since measureStep.ts is at 100% 

![image](https://github.com/Zizzamia/perfume.js/assets/50121662/9cf11822-5f53-436b-b367-0afd61ad87b4)
