### PR TITLE
Fix import crash under node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.3.1 (2024-4-21)
+
+* **fix**: Fix import crash under node.js
+
 ## 9.3.0 (2024-2-24)
 
 * **fix**: Added extra check for undefined values. #260

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfume.js",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Web performance library for measuring all User-centric performance metrics, including the latest Web Vitals.",
   "keywords": [
     "performance",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Have private variable outside the class,
 // helps drastically reduce the library size
-export const W = window;
+export const W = globalThis;
 export const C = W.console;
 export const WN = W.navigator;
 export const WP = W.performance;


### PR DESCRIPTION
This library can be imported under node.js for SSR projects (even though it is not actually used).

Because perfume.js is referring to "window" which does not exist under node.js, this is currently causing a crash.

This PR is addressing that issue by using globalThis (which refers to window in browsers, and global in node).

