### PR TITLE
feat: improve IPerfumeData types and usage

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -5,22 +5,33 @@ import { visibility } from './onVisibilityChange';
 import { po } from './performanceObserver';
 import { reportPerf } from './reportPerf';
 import { initTotalBlockingTime } from './totalBlockingTime';
-import { Metric } from './types';
+import { IPerfumeData, Metric } from './types';
 import { roundByFour } from './utils';
 import { getVitalsScore } from './vitalsScore';
 
 export const logData = (
   measureName: string,
-  metric: any,
+  metric: IPerfumeData,
   attribution?: object,
 ): void => {
-  Object.keys(metric).forEach(key => {
-    if (typeof metric[key] === 'number') {
-      metric[key] = roundByFour(metric[key]);
+  const roundNumericProperties = (data: IPerfumeData): IPerfumeData => {
+    if (typeof data === 'number') {
+      return data;
     }
-  });
+
+    return Object.entries(data).reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: typeof value === 'number' ? roundByFour(value) : value,
+      }),
+      {} as typeof data,
+    );
+  };
+
+  const convertedMetric = roundNumericProperties(metric);
+
   // Sends the metric to an external tracking service
-  reportPerf(measureName, metric, null, attribution || {});
+  reportPerf(measureName, convertedMetric, null, attribution || {});
 };
 
 /**

--- a/src/reportPerf.ts
+++ b/src/reportPerf.ts
@@ -1,7 +1,7 @@
 import { config } from './config';
 import { getNavigatorInfo } from './getNavigatorInfo';
 import { visibility } from './onVisibilityChange';
-import { IVitalsScore, INavigationType } from './types';
+import { IVitalsScore, INavigationType, IPerfumeData } from './types';
 import { pushTask } from './utils';
 
 /**
@@ -9,7 +9,7 @@ import { pushTask } from './utils';
  */
 export const reportPerf = (
   measureName: string,
-  data: any,
+  data: IPerfumeData,
   rating: IVitalsScore,
   attribution: object,
   navigationType?: INavigationType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,14 @@ export interface IPerfumeNetworkInformation {
   saveData?: boolean;
 }
 
+export interface IPerfumeStorageEstimate {
+  quota: number | null;
+  usage: number | null;
+  caches: number | null;
+  indexedDB: number | null;
+  serviceWorker: number | null;
+}
+
 export interface IPerfumeDataConsumption {
   beacon: number;
   css: number;
@@ -213,7 +221,10 @@ export interface IPerfumeDataConsumption {
 export type IPerfumeData =
   | number
   | IPerfumeNavigationTiming
-  | IPerfumeNetworkInformation;
+  | IPerfumeNetworkInformation
+  | IPerfumeStorageEstimate
+  | IPerfumeDataConsumption
+  | IPerformanceEntry;
 
 export type IVitalsScore = 'good' | 'needsImprovement' | 'poor' | null;
 


### PR DESCRIPTION
# Motivation

I noticed that the `IPerfumeData` type was incomplete. There was some usage of `any`, and the type did not declare all possible properties.

This PR aims to improve this to ease the usage of the library.

# Changes

- Created the type `IPerfumeStorageEstimate`.
- Extended `IPerfumeData` with `IPerfumeStorageEstimate`, `IPerfumeDataConsumption`, and `IPerformanceEntry`.
- Replaced `any` usage with specific types.
- Rewrote the function that maps the numbers in `logData` to comply with ESLint and type usage. A functional approach that does not modify the type passed as a parameter is preferable.

# Tests

One test is failing, similar to when I ran the test suite on the main branch. Therefore, I assume that the tests are currently broken, and providing the exact same results validates the refactoring.
